### PR TITLE
Added API function

### DIFF
--- a/VocalTractLabApi.cpp
+++ b/VocalTractLabApi.cpp
@@ -277,6 +277,31 @@ int vtlClose()
 
 
 // ****************************************************************************
+// Switch to turn off/on the automatic calculation of the tongue root 
+// parameters TRX and TRY.
+//
+// Return values:
+// 0: success.
+// 1: The API was not initialized.
+// ****************************************************************************
+
+int vtlCalcTongueRootAutomatically(bool automaticCalculation)
+{
+    if (!vtlApiInitialized)
+    {
+        printf("Error: The API was not initialized.\n");
+        return 1;
+    }
+
+    vocalTract->anatomy.automaticTongueRootCalc = automaticCalculation;
+    vocalTract->calculateAll();
+
+    return 0;
+}
+
+
+
+// ****************************************************************************
 // Returns the version of this API as a string that contains the compile data.
 // Reserve at least 32 chars for the string.
 // ****************************************************************************

--- a/VocalTractLabApi.def
+++ b/VocalTractLabApi.def
@@ -2,6 +2,7 @@ LIBRARY
 EXPORTS
 vtlInitialize
 vtlClose
+vtlCalcTongueRootAutomatically
 vtlGetVersion
 vtlGetConstants
 vtlGetTractParamInfo

--- a/VocalTractLabApi.h
+++ b/VocalTractLabApi.h
@@ -72,6 +72,18 @@ C_EXPORT int vtlClose();
 
 
 // ****************************************************************************
+// Switch to turn off/on the automatic calculation of the tongue root 
+// parameters TRX and TRY.
+//
+// Return values:
+// 0: success.
+// 1: The API was not initialized.
+// ****************************************************************************
+
+C_EXPORT int vtlCalcTongueRootAutomatically(bool automaticCalculation);
+
+
+// ****************************************************************************
 // Returns the version of this API as a string that contains the compile data.
 // Reserve at least 32 chars for the string.
 // ****************************************************************************


### PR DESCRIPTION
Added a switch to turn on / off the automatic calculation of the tongue root parameters in the API.
Note that, even with automatic calculation turned off, the parameters are still influenced by the biological constraints in the function restrictTongueParams().