### PR TITLE
Changed the function vtlGetTransferFunction() 

### DIFF
--- a/Unit Tests/test.cpp
+++ b/Unit Tests/test.cpp
@@ -133,6 +133,51 @@ TEST(ApiTest, TractToTube)
 	vtlClose();
 }
 
+TEST(ApiTest, DefaultTransferFunctionOptions)
+{
+	vtlInitialize(speakerFile);
+
+	TransferFunctionOptions defaultOpts;
+	int ret = vtlGetDefaultTransferFunctionOptions(&defaultOpts);
+
+	EXPECT_EQ(ret, 0);
+	EXPECT_EQ(defaultOpts.radiation, PARALLEL_RADIATION);
+	EXPECT_EQ(defaultOpts.boundaryLayer, true);
+	EXPECT_EQ(defaultOpts.heatConduction, false);
+	EXPECT_EQ(defaultOpts.softWalls, true);
+	EXPECT_EQ(defaultOpts.hagenResistance, false);
+	EXPECT_EQ(defaultOpts.lumpedElements, true);
+	EXPECT_EQ(defaultOpts.innerLengthCorrections, false);
+	EXPECT_EQ(defaultOpts.paranasalSinuses, true);
+	EXPECT_EQ(defaultOpts.piriformFossa, true);
+	EXPECT_EQ(defaultOpts.staticPressureDrops, true);
+	EXPECT_EQ(defaultOpts.type, SPECTRUM_UU);
+}
+
+TEST(ApiTest, GetTransferFunction)
+{
+	vtlInitialize(speakerFile);
+
+	TransferFunctionOptions opts;
+	vtlGetDefaultTransferFunctionOptions(&opts);
+	opts.type = SPECTRUM_PU;
+
+	int _, numVocalTractParams;
+	vtlGetConstants(&_, &_, &numVocalTractParams, &_);
+	
+	std::vector<double> tractParams(numVocalTractParams);
+	vtlGetTractParams("a", &tractParams[0]);
+	
+	const int numSamples = 4096;
+	std::vector<double> magnitude(numSamples);
+	std::vector<double> phase(numSamples);
+	int ret = vtlGetTransferFunction(&tractParams[0], numSamples,
+		&opts, &magnitude[0], &phase[0]);
+
+	EXPECT_EQ(ret, 0);
+}
+
+
 TEST(ApiTest, GesToAudio_FileOut)
 {
 	vtlInitialize(speakerFile);

--- a/VocalTractLabApi.cpp
+++ b/VocalTractLabApi.cpp
@@ -562,7 +562,35 @@ int vtlTractToTube(double *tractParams,
 
 
 // ****************************************************************************
-// Calculates the volume velocity transfer function of the vocal tract between 
+// Returns the default options for the transfer function calculation. 
+// 
+// Parameters out:
+// o opts: A struct containing the default values for the options available for
+// the transfer function calculation.
+//
+// Function return value:
+// 0: success.
+// 1: The API has not been initialized.
+// ****************************************************************************
+
+int vtlGetDefaultTransferFunctionOptions(TransferFunctionOptions* opts)
+{
+    opts->radiation = PARALLEL_RADIATION;
+    opts->boundaryLayer = true;
+    opts->heatConduction = false;
+    opts->softWalls = true;
+    opts->hagenResistance = false;
+    opts->lumpedElements = true;
+    opts->innerLengthCorrections = false;
+    opts->paranasalSinuses = true;
+    opts->piriformFossa = true;
+    opts->staticPressureDrops = true;
+    opts->type = SPECTRUM_UU;
+    return 0;
+}
+
+// ****************************************************************************
+// Calculates the transfer function of the vocal tract between 
 // the glottis and the lips for the given vector of vocal tract parameters and
 // returns the spectrum in terms of magnitude and phase.
 //
@@ -579,7 +607,10 @@ int vtlTractToTube(double *tractParams,
 //     at the frequencies 0.0, 86.13, 172.3, ... Hz.
 //     The value of numSpectrumSamples should not be greater than 16384,
 //     otherwise the returned spectrum will be bandlimited to below 10 kHz.
-//
+// o opts: The options to use for the transfer function calculation. If NULL 
+//     is passed, the default options will be used (see 
+//     vtlGetDefaultTransferFunctionOptions()).
+// 
 // Parameters out:
 // o magnitude: Vector of spectral magnitudes at equally spaced discrete 
 //     frequencies. This vector mus have at least numSpectrumSamples elements.
@@ -592,49 +623,76 @@ int vtlTractToTube(double *tractParams,
 // 1: The API has not been initialized.
 // ****************************************************************************
 
-int vtlGetTransferFunction(double *tractParams, int numSpectrumSamples,
-  double *magnitude, double *phase_rad)
+int vtlGetTransferFunction(double* tractParams, int numSpectrumSamples, TransferFunctionOptions* opts, double* magnitude, double* phase_rad)
 {
-  if (!vtlApiInitialized)
-  {
-    printf("Error: The API has not been initialized.\n");
-    return 1;
-  }
+    if (!vtlApiInitialized)
+    {
+        printf("Error: The API has not been initialized.\n");
+        return 1;
+    }
 
-  int i;
-  ComplexSignal s;
+    int i;
+    ComplexSignal s;
 
-  if (numSpectrumSamples < 16)
-  {
-    numSpectrumSamples = 16;
-  }
+    if (numSpectrumSamples < 16)
+    {
+        numSpectrumSamples = 16;
+    }
 
-  // Calculate the vocal tract shape from the vocal tract parameters.
+    // Calculate the vocal tract shape from the vocal tract parameters.
 
-  for (i = 0; i < VocalTract::NUM_PARAMS; i++)
-  {
-    vocalTract->param[i].x = tractParams[i];
-  }
-  vocalTract->calculateAll();
+    for (i = 0; i < VocalTract::NUM_PARAMS; i++)
+    {
+        vocalTract->param[i].x = tractParams[i];
+    }
+    vocalTract->calculateAll();
 
-  // Calculate the transfer function.
+    // Calculate the transfer function.
 
-  TlModel *tlModel = new TlModel();
-  vocalTract->getTube(&tlModel->tube);
-  tlModel->tube.setGlottisArea(0.0);
-  tlModel->getSpectrum(TlModel::FLOW_SOURCE_TF, &s, numSpectrumSamples, Tube::FIRST_PHARYNX_SECTION);
+    TlModel* tlModel = new TlModel();
 
-  // Separate the transfer function into magnitude and phase.
+    // Set the options
+    TlModel::Options tlOpts;
+    if (opts == NULL)
+    {
+      TransferFunctionOptions tfOpts;
+      vtlGetDefaultTransferFunctionOptions(&tfOpts);
+      opts = &tfOpts;
+    }
+    tlOpts.boundaryLayer = opts->boundaryLayer;
+    tlOpts.hagenResistance = opts->hagenResistance;
+    tlOpts.heatConduction = opts->heatConduction;
+    tlOpts.innerLengthCorrections = opts->innerLengthCorrections;
+    tlOpts.lumpedElements = opts->lumpedElements;
+    tlOpts.paranasalSinuses = opts->paranasalSinuses;
+    tlOpts.piriformFossa = opts->piriformFossa;
+    tlOpts.radiation = (TlModel::RadiationType)opts->radiation;
+    tlOpts.softWalls = opts->softWalls;
 
-  for (i = 0; i < numSpectrumSamples; i++)
-  {
-    magnitude[i] = s.getMagnitude(i);
-    phase_rad[i] = s.getPhase(i);
-  }
+    tlModel->options = tlOpts;
+    vocalTract->getTube(&tlModel->tube);
+    tlModel->tube.setGlottisArea(0.0);
 
-  delete tlModel;
+    tlModel->getSpectrum(TlModel::FLOW_SOURCE_TF, &s, numSpectrumSamples, Tube::FIRST_PHARYNX_SECTION);
 
-  return 0;
+    if (opts->type == SPECTRUM_PU)
+    {
+        ComplexSignal radiationSpectrum(0);
+        tlModel->getSpectrum(TlModel::RADIATION, &radiationSpectrum, numSpectrumSamples, 0);
+        s *= radiationSpectrum;
+        s *= 10.0;
+    }
+
+    // Separate the transfer function into magnitude and phase.
+    for (i = 0; i < numSpectrumSamples; i++)
+    {
+        magnitude[i] = s.getMagnitude(i);
+        phase_rad[i] = s.getPhase(i);
+    }
+
+    delete tlModel;
+
+    return 0;
 }
 
 

--- a/VocalTractLabApi.cpp
+++ b/VocalTractLabApi.cpp
@@ -575,7 +575,7 @@ int vtlTractToTube(double *tractParams,
 
 int vtlGetDefaultTransferFunctionOptions(TransferFunctionOptions* opts)
 {
-    opts->radiation = PARALLEL_RADIATION;
+    opts->radiationType = PARALLEL_RADIATION;
     opts->boundaryLayer = true;
     opts->heatConduction = false;
     opts->softWalls = true;
@@ -585,7 +585,7 @@ int vtlGetDefaultTransferFunctionOptions(TransferFunctionOptions* opts)
     opts->paranasalSinuses = true;
     opts->piriformFossa = true;
     opts->staticPressureDrops = true;
-    opts->type = SPECTRUM_UU;
+    opts->spectrumType = SPECTRUM_UU;
     return 0;
 }
 
@@ -666,7 +666,7 @@ int vtlGetTransferFunction(double* tractParams, int numSpectrumSamples, Transfer
     tlOpts.lumpedElements = opts->lumpedElements;
     tlOpts.paranasalSinuses = opts->paranasalSinuses;
     tlOpts.piriformFossa = opts->piriformFossa;
-    tlOpts.radiation = (TlModel::RadiationType)opts->radiation;
+    tlOpts.radiation = (TlModel::RadiationType)opts->radiationType;
     tlOpts.softWalls = opts->softWalls;
 
     tlModel->options = tlOpts;
@@ -675,7 +675,7 @@ int vtlGetTransferFunction(double* tractParams, int numSpectrumSamples, Transfer
 
     tlModel->getSpectrum(TlModel::FLOW_SOURCE_TF, &s, numSpectrumSamples, Tube::FIRST_PHARYNX_SECTION);
 
-    if (opts->type == SPECTRUM_PU)
+    if (opts->spectrumType == SPECTRUM_PU)
     {
         ComplexSignal radiationSpectrum(0);
         tlModel->getSpectrum(TlModel::RADIATION, &radiationSpectrum, numSpectrumSamples, 0);

--- a/VocalTractLabApi.def
+++ b/VocalTractLabApi.def
@@ -9,6 +9,7 @@ vtlGetGlottisParamInfo
 vtlGetTractParams
 vtlExportTractSvg
 vtlTractToTube
+vtlGetDefaultTransferFunctionOptions
 vtlGetTransferFunction
 vtlInputTractToLimitedTract
 vtlSynthesisReset

--- a/VocalTractLabApi.h
+++ b/VocalTractLabApi.h
@@ -171,6 +171,67 @@ C_EXPORT int vtlTractToTube(double* tractParams,
 
 
 // ****************************************************************************
+// Enumerates the different options to model radiation of the sound wave
+// from the mouth
+// ****************************************************************************
+
+typedef enum
+{
+    NO_RADIATION,
+    PISTONINSPHERE_RADIATION,
+    PISTONINWALL_RADIATION,
+    PARALLEL_RADIATION,
+    NUM_RADIATION_OPTIONS
+} RadiationType;
+
+
+// ****************************************************************************
+// Enumerates the different types of spectra (or transfer functions)
+// ****************************************************************************
+
+typedef enum
+{
+    SPECTRUM_UU,  // Output flow over input flow
+    SPECTRUM_PU   // Output output pressure over input flow
+} SpectrumType;
+
+
+// ****************************************************************************
+// A struct containing the various options available for the calculation 
+// of the vocal tract transfer function
+// ****************************************************************************
+
+typedef struct
+{
+    SpectrumType type;              // What kind of transfer function to calculate
+    RadiationType radiation;        // Radiation model
+    bool boundaryLayer;             // Consider boundary layer resistance
+    bool heatConduction;            // Consider heat conduction losses
+    bool softWalls;                 // Consider soft walls
+    bool hagenResistance;           // Consider Hagen-Poiseuille resistance
+    bool innerLengthCorrections;    // Make inner (tube) length corrections
+    bool lumpedElements;            // Use lumped elements in T-sections
+    bool paranasalSinuses;          // Include the paranasal sinuses
+    bool piriformFossa;             // Include the piriform fossa
+    bool staticPressureDrops;       // Consider static pressure drops
+} TransferFunctionOptions;
+
+
+// ****************************************************************************
+// Returns the default options for the transfer function calculation. 
+// 
+// Parameters out:
+// o opts: A struct containing the default values for the options available for
+// the transfer function calculation.
+//
+// Function return value:
+// 0: success.
+// 1: The API has not been initialized.
+// ****************************************************************************
+C_EXPORT int vtlGetDefaultTransferFunctionOptions(TransferFunctionOptions* opts);
+
+
+// ****************************************************************************
 // Calculates the volume velocity transfer function of the vocal tract between 
 // the glottis and the lips for the given vector of vocal tract parameters and
 // returns the spectrum in terms of magnitude and phase.
@@ -188,7 +249,10 @@ C_EXPORT int vtlTractToTube(double* tractParams,
 //     at the frequencies 0.0, 86.13, 172.3, ... Hz.
 //     The value of numSpectrumSamples should not be greater than 16384,
 //     otherwise the returned spectrum will be bandlimited to below 10 kHz.
-//
+// o opts: The options to use for the transfer function calculation. If NULL 
+//     is passed, the default options will be used (see 
+//     vtlGetDefaultTransferFunctionOptions()).
+// 
 // Parameters out:
 // o magnitude: Vector of spectral magnitudes at equally spaced discrete 
 //     frequencies. This vector mus have at least numSpectrumSamples elements.
@@ -201,8 +265,8 @@ C_EXPORT int vtlTractToTube(double* tractParams,
 // 1: The API has not been initialized.
 // ****************************************************************************
 
-C_EXPORT int vtlGetTransferFunction(double *tractParams, int numSpectrumSamples,
-  double *magnitude, double *phase_rad);
+C_EXPORT int vtlGetTransferFunction(double* tractParams, int numSpectrumSamples,
+    TransferFunctionOptions* opts, double* magnitude, double* phase_rad);
 
 
 // ****************************************************************************

--- a/VocalTractLabApi.h
+++ b/VocalTractLabApi.h
@@ -203,8 +203,8 @@ typedef enum
 
 typedef struct
 {
-    SpectrumType type;              // What kind of transfer function to calculate
-    RadiationType radiation;        // Radiation model
+    SpectrumType spectrumType;      // What kind of transfer function to calculate
+    RadiationType radiationType;        // Radiation model
     bool boundaryLayer;             // Consider boundary layer resistance
     bool heatConduction;            // Consider heat conduction losses
     bool softWalls;                 // Consider soft walls


### PR DESCRIPTION
...so that (transmission line model) options can be changed instead of enforcing their default values. Since the function's signature changed, this is a breaking change that makes the API incompatible with older versions.