### PR TITLE
Extended the API function vtlGetConstants() to return more values

### DIFF
--- a/VocalTractLabApi.cpp
+++ b/VocalTractLabApi.cpp
@@ -325,7 +325,8 @@ void vtlGetVersion(char *version)
 // ****************************************************************************
 
 int vtlGetConstants(int *audioSamplingRate, int *numTubeSections,
-  int *numVocalTractParams, int *numGlottisParams)
+                    int *numVocalTractParams, int *numGlottisParams,
+                    int *numAudioSamplesPerTractState, double *internalSamplingRate)
 {
   if (!vtlApiInitialized)
   {
@@ -337,6 +338,9 @@ int vtlGetConstants(int *audioSamplingRate, int *numTubeSections,
   *numTubeSections = Tube::NUM_PHARYNX_MOUTH_SECTIONS;
   *numVocalTractParams = VocalTract::NUM_PARAMS;
   *numGlottisParams = (int)glottis[selectedGlottis]->controlParam.size();
+  *numAudioSamplesPerTractState = Synthesizer::NUM_CHUNCK_SAMPLES;
+  *internalSamplingRate = (double)SAMPLING_RATE / (double)Synthesizer::NUM_CHUNCK_SAMPLES;
+
 
   return 0;
 }
@@ -1011,12 +1015,14 @@ int vtlApiTest(const char *speakerFileName, double *audio, int *numSamples)
   vtlGetVersion(version);
   printf("Compile date of the library: %s\n", version);
 
-  int audioSamplingRate = 0;
-  int numTubeSections = 0;
-  int numVocalTractParams = 0;
-  int numGlottisParams = 0;
+  int audioSamplingRate = -1;
+  int numTubeSections = -1;
+  int numVocalTractParams = -1;
+  int numGlottisParams = -1;
+  int numAudioSamplesPerTractState = -1;
+  double internalSamplingRate = -1.0;
 
-  vtlGetConstants(&audioSamplingRate, &numTubeSections, &numVocalTractParams, &numGlottisParams);
+  vtlGetConstants(&audioSamplingRate, &numTubeSections, &numVocalTractParams, &numGlottisParams, &numAudioSamplesPerTractState, &internalSamplingRate);
 
   printf("Audio sampling rate = %d\n", audioSamplingRate);
   printf("Num. of tube sections = %d\n", numTubeSections);

--- a/VocalTractLabApi.h
+++ b/VocalTractLabApi.h
@@ -43,6 +43,8 @@ extern "C"{ /* start extern "C" */
   #define C_EXPORT
 #endif  // WIN32
 
+//typedef enum { false, true } bool; // Important for compilation with cython
+
 // ****************************************************************************
 // The exported C-compatible functions.
 // IMPORTANT: 
@@ -97,6 +99,8 @@ C_EXPORT void vtlGetVersion(char *version);
 // o The number of supraglottal tube sections.
 // o The number of vocal tract model parameters.
 // o The number of glottis model parameters.
+// o The number of audio samples that correspond to a single tract state sample
+// o The number of evaluated tract state samples per second (internal sampling rate).
 //
 // Function return value:
 // 0: success.
@@ -104,7 +108,7 @@ C_EXPORT void vtlGetVersion(char *version);
 // ****************************************************************************
 
 C_EXPORT int vtlGetConstants(int *audioSamplingRate, int *numTubeSections,
-  int *numVocalTractParams, int *numGlottisParams);
+  int *numVocalTractParams, int *numGlottisParams, int *numAudioSamplesPerTractState, double *internalSamplingRate);
 
 
 // ****************************************************************************


### PR DESCRIPTION
vtlGetConstants() now additionally returns the number of audio samples that correspond to a single tract sate sample (currently 110) and the related internal sampling rate (number of tract states evaluated per second, ~400.9090...).

Function is tested and working.