### PR TITLE
Added verbose-switch for vtlSegmentSequenceToGesturalScore()

### DIFF
--- a/GesturalScore.cpp
+++ b/GesturalScore.cpp
@@ -821,12 +821,12 @@ void GesturalScore::initTestScore()
 /// and their durations).
 // ****************************************************************************
 
-void GesturalScore::createFromSegmentSequence(SegmentSequence *origSegmentSequence, int enableConsoleOutput)
+void GesturalScore::createFromSegmentSequence(SegmentSequence *origSegmentSequence, bool enableConsoleOutput)
 {
   const double MIN_GESTURE_DURATION_S = (double)MIN_GESTURE_DURATION_MS * 0.001;
   int i;
 
-  if (enableConsoleOutput != 0)
+  if (enableConsoleOutput)
   {
       printf("Creating a gestural score from %d segments.\n", origSegmentSequence->numSegments());
   }

--- a/GesturalScore.cpp
+++ b/GesturalScore.cpp
@@ -821,12 +821,15 @@ void GesturalScore::initTestScore()
 /// and their durations).
 // ****************************************************************************
 
-void GesturalScore::createFromSegmentSequence(SegmentSequence *origSegmentSequence)
+void GesturalScore::createFromSegmentSequence(SegmentSequence *origSegmentSequence, int enableConsoleOutput)
 {
   const double MIN_GESTURE_DURATION_S = (double)MIN_GESTURE_DURATION_MS * 0.001;
   int i;
 
-  printf("Creating a gestural score from %d segments.\n", origSegmentSequence->numSegments());
+  if (enableConsoleOutput != 0)
+  {
+      printf("Creating a gestural score from %d segments.\n", origSegmentSequence->numSegments());
+  }
 
 
   // ****************************************************************

--- a/GesturalScore.h
+++ b/GesturalScore.h
@@ -177,7 +177,7 @@ public:
   
   void clear();
   void initTestScore();
-  void createFromSegmentSequence(SegmentSequence *origSegmentSequence, int enableConsoleOutput);
+  void createFromSegmentSequence(SegmentSequence *origSegmentSequence, bool enableConsoleOutput = true );
   
   void addClosingGesture(GestureType gestureType, string gestureName, 
     double closureBegin_s, double closureEnd_s, bool connectToPrevGesture);

--- a/GesturalScore.h
+++ b/GesturalScore.h
@@ -177,7 +177,7 @@ public:
   
   void clear();
   void initTestScore();
-  void createFromSegmentSequence(SegmentSequence *origSegmentSequence);
+  void createFromSegmentSequence(SegmentSequence *origSegmentSequence, int enableConsoleOutput);
   
   void addClosingGesture(GestureType gestureType, string gestureName, 
     double closureBegin_s, double closureEnd_s, bool connectToPrevGesture);

--- a/VocalTractLabApi.cpp
+++ b/VocalTractLabApi.cpp
@@ -1182,7 +1182,7 @@ int vtlApiTest(const char *speakerFileName, double *audio, int *numSamples)
 // 3: Saving the gestural score file failed.
 // ****************************************************************************
 
-int vtlSegmentSequenceToGesturalScore(const char *segFileName, const char *gesFileName)
+int vtlSegmentSequenceToGesturalScore(const char *segFileName, const char *gesFileName, int enableConsoleOutput)
 {
   if (!vtlApiInitialized)
   {
@@ -1203,7 +1203,7 @@ int vtlSegmentSequenceToGesturalScore(const char *segFileName, const char *gesFi
   // Create and save the gestural score.
 
   GesturalScore *gesturalScore = new GesturalScore(vocalTract, glottis[selectedGlottis]);
-  gesturalScore->createFromSegmentSequence(segmentSequence);
+  gesturalScore->createFromSegmentSequence(segmentSequence, enableConsoleOutput);
   if (gesturalScore->saveGesturesXml(string(gesFileName)) == false)
   {
     delete segmentSequence;

--- a/VocalTractLabApi.cpp
+++ b/VocalTractLabApi.cpp
@@ -943,7 +943,7 @@ int vtlSynthesisAddTract(int numNewSamples, double *audio,
 // ****************************************************************************
 
 int vtlSynthBlock(double *tractParams, double *glottisParams,
-  int numFrames, int frameStep_samples, double *audio, int enableConsoleOutput)
+  int numFrames, int frameStep_samples, double *audio, bool enableConsoleOutput)
 {
   if (!vtlApiInitialized)
   {
@@ -955,7 +955,7 @@ int vtlSynthBlock(double *tractParams, double *glottisParams,
   int samplePos = 0;
   int numGlottisParams = (int)glottis[selectedGlottis]->controlParam.size();
 
-  if (enableConsoleOutput != 0)
+  if (enableConsoleOutput)
   {
     printf("Block synthesis in progress ...");
   }
@@ -1182,7 +1182,7 @@ int vtlApiTest(const char *speakerFileName, double *audio, int *numSamples)
 // 3: Saving the gestural score file failed.
 // ****************************************************************************
 
-int vtlSegmentSequenceToGesturalScore(const char *segFileName, const char *gesFileName, int enableConsoleOutput)
+int vtlSegmentSequenceToGesturalScore(const char *segFileName, const char *gesFileName, bool enableConsoleOutput)
 {
   if (!vtlApiInitialized)
   {
@@ -1243,7 +1243,7 @@ int vtlSegmentSequenceToGesturalScore(const char *segFileName, const char *gesFi
 // ****************************************************************************
 
 int vtlGesturalScoreToAudio(const char *gesFileName, const char *wavFileName,
-  double *audio, int *numSamples, int enableConsoleOutput)
+  double *audio, int *numSamples, bool enableConsoleOutput)
 {
   if (!vtlApiInitialized)
   {
@@ -1282,7 +1282,7 @@ int vtlGesturalScoreToAudio(const char *gesFileName, const char *wavFileName,
   // ****************************************************************
 
   vector<double> audioVector;
-  Synthesizer::synthesizeGesturalScore(gesturalScore, tdsModel, audioVector, (bool)enableConsoleOutput);
+  Synthesizer::synthesizeGesturalScore(gesturalScore, tdsModel, audioVector, enableConsoleOutput);
   int numVectorSamples = (int)audioVector.size();
 
   // ****************************************************************

--- a/VocalTractLabApi.h
+++ b/VocalTractLabApi.h
@@ -43,6 +43,8 @@ extern "C"{ /* start extern "C" */
   #define C_EXPORT
 #endif  // WIN32
 
+#include <stdbool.h>
+
 // ****************************************************************************
 // The exported C-compatible functions.
 // IMPORTANT: 
@@ -401,7 +403,7 @@ C_EXPORT int vtlSynthesisAddTract(int numNewSamples, double *audio,
 // ****************************************************************************
 
 C_EXPORT int vtlSynthBlock(double *tractParams, double *glottisParams,
-  int numFrames, int frameStep_samples, double *audio, int enableConsoleOutput);
+  int numFrames, int frameStep_samples, double *audio, bool enableConsoleOutput);
 
 
 // ****************************************************************************
@@ -429,7 +431,7 @@ C_EXPORT int vtlApiTest(const char *speakerFileName, double *audio, int *numSamp
 // 3: Saving the gestural score file failed.
 // ****************************************************************************
 
-C_EXPORT int vtlSegmentSequenceToGesturalScore(const char *segFileName, const char *gesFileName, int enableConsoleOutput);
+C_EXPORT int vtlSegmentSequenceToGesturalScore(const char *segFileName, const char *gesFileName, bool enableConsoleOutput);
 
 
 // ****************************************************************************
@@ -456,7 +458,7 @@ C_EXPORT int vtlSegmentSequenceToGesturalScore(const char *segFileName, const ch
 // ****************************************************************************
 
 C_EXPORT int vtlGesturalScoreToAudio(const char* gesFileName, const char* wavFileName,
-  double* audio, int* numSamples, int enableConsoleOutput);
+  double* audio, int* numSamples, bool enableConsoleOutput);
 
 
 // ****************************************************************************

--- a/VocalTractLabApi.h
+++ b/VocalTractLabApi.h
@@ -419,6 +419,9 @@ C_EXPORT int vtlApiTest(const char *speakerFileName, double *audio, int *numSamp
 // name segFileName into a gestural score file (gesFileName).
 // The f0 tier in the gestural score is set to a "standard" f0.
 //
+// o enableConsoleOutput (in): Set to 1, if you want to allow output about the
+//   synthesis progress in the console window. Otherwise, set it to 0.
+//
 // Function return value:
 // 0: success.
 // 1: The API was not initialized.
@@ -426,7 +429,7 @@ C_EXPORT int vtlApiTest(const char *speakerFileName, double *audio, int *numSamp
 // 3: Saving the gestural score file failed.
 // ****************************************************************************
 
-C_EXPORT int vtlSegmentSequenceToGesturalScore(const char *segFileName, const char *gesFileName);
+C_EXPORT int vtlSegmentSequenceToGesturalScore(const char *segFileName, const char *gesFileName, int enableConsoleOutput);
 
 
 // ****************************************************************************


### PR DESCRIPTION
Added a switch to enable/disable the console output from the function vtlSegmentSequenceToGesturalScore().

Function is tested and working.