### PR TITLE
Feature ema and mesh export through api

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This repo contains sources of the backend of the articulatory synthesizer [Vocal
 ```
 git clone https://github.com/TUD-STKS/VocalTractLabBackend-dev
 ```
+
 ### Build using CMake (Windows, Linux, macOS)
 - Get the latet release of [CMake for your platform](https://cmake.org/)
 - Create a folder ``out`` inside the cloned repository folder
@@ -40,6 +41,14 @@ or
 cmake --build . --config Release --target VocalTractLabBackend
 ```
 
+### Run tests using shell/command prompt
+- Open a shell/command prompt
+- Navigate to cloned repository folder (not the ``out`` folder from the build process)
+- run the tests by executing ``VtlApiTests`` in the ``lib`` folder created by the build process:
+```
+./lib/VtlApiTests
+```
+
 ### Build using Visual Studio 2019 (Windows)
 - Open ``VocalTractLabApi.sln`` in the folder `build/msw`
 - Build the project ``VocalTractLabApi`` or ``VocalTractLabBackend``
@@ -48,13 +57,11 @@ cmake --build . --config Release --target VocalTractLabBackend
 To include the VocalTractLab backend into your own projects, add the folder `include` from this repository to your project's include directories and link against the API or static backend library in the folder `lib`. 
 
 You can then include the API functions like so:
-
 ```cpp
 #include "VocalTractLabApi/VocalTractLabApi.h"
 ```
 
 C++-Objects can be included from the static backend library through their respective header:
-
 ```cpp
 #include "VocalTractLabBackend/Speaker.h"  // or substitute your desired header here
 ```

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ or
 ```
 cmake --build . --config Release --target VocalTractLabBackend
 ```
+The final dll/so-files and executables are copied to ``../lib/`` so you don't
+find them within the ``out`` folder.
 
 ### Run tests using shell/command prompt
 - Open a shell/command prompt

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ The main branch of this repo is reviewed on a semi-regular basis for inclusion i
 
 This repo may be included in other repos as a submodule wherever the backend source code or the C/C++ API is needed.
 
+## What you can find in this repo
+This repo contains sources of the backend of the articulatory synthesizer [VocalTractLab](https://www.vocaltractlab.de). The backend can be accessed through a C/C++ API offering convenient C-style functions to provide the most commonly used functionality (e.g. converting a gestural score file into an audio file using default synthesis settings), or as a static C++ library for full access to all objects in the backend. This repo therefore contains separate projects/targets for both the C/C++ API and the C++ static library.
+
 ## Getting started
 - Clone the current main branch:
 ```
@@ -18,7 +21,7 @@ git clone https://github.com/TUD-STKS/VocalTractLabBackend-dev
 ```
 ### Build using CMake (Windows, Linux, macOS)
 - Get the latet release of [CMake for your platform](https://cmake.org/)
-- Create a folder ``out``inside the cloned repository folder
+- Create a folder ``out`` inside the cloned repository folder
 - Open a shell/command prompt and navigate to ``out``
 - Configure the project and generate a build system:
 ```
@@ -28,8 +31,33 @@ cmake ..
 ```
 cmake --build . --config Release
 ```
+This will build both the API and the static library, as well as some unit testing executables. If you are only interested in one of those, you can specify the `--target` parameter:
+```
+cmake --build . --config Release --target VocalTractLabApi
+```
+or
+```
+cmake --build . --config Release --target VocalTractLabBackend
+```
 
 ### Build using Visual Studio 2019 (Windows)
 - Open ``VocalTractLabApi.sln`` in the folder `build/msw`
-- Build the project ``VocalTractLabApi``
+- Build the project ``VocalTractLabApi`` or ``VocalTractLabBackend``
 
+### Use the VocalTractLab backend in your own projects
+To include the VocalTractLab backend into your own projects, add the folder `include` from this repository to your project's include directories and link against the API or static backend library in the folder `lib`. 
+
+You can then include the API functions like so:
+
+```cpp
+#include "VocalTractLabApi/VocalTractLabApi.h"
+```
+
+C++-Objects can be included from the static backend library through their respective header:
+
+```cpp
+#include "VocalTractLabBackend/Speaker.h"  // or substitute your desired header here
+```
+
+## How to use the VocalTractLab backend
+The VocalTractLab API functions are documented with extensive comments in `VocalTractLabApi.h`. Unfortunately, since they were not previously public, the classes beyond the API in the static library are not (yet) documented consistently.

--- a/build/msw/VocalTractLabApi.vcxproj
+++ b/build/msw/VocalTractLabApi.vcxproj
@@ -159,6 +159,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -173,7 +174,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\include\VocalTractLabBackend;..\..\include\VocalTractLabApi;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpp14</LanguageStandard>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -194,6 +195,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -214,7 +216,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\include\VocalTractLabBackend;..\..\include\VocalTractLabApi;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpp14</LanguageStandard>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/build/msw/VocalTractLabBackend.vcxproj
+++ b/build/msw/VocalTractLabBackend.vcxproj
@@ -167,6 +167,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>
@@ -184,6 +185,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>
@@ -202,7 +204,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>..\..\include\VocalTractLabBackend;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpp14</LanguageStandard>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>
@@ -221,7 +223,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>..\..\include\VocalTractLabBackend;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpp14</LanguageStandard>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>

--- a/build/msw/VocalTractLabBackend.vcxproj
+++ b/build/msw/VocalTractLabBackend.vcxproj
@@ -1,9 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug_vcpkg|Win32">
+      <Configuration>Debug_vcpkg</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug_vcpkg|x64">
+      <Configuration>Debug_vcpkg</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
       <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release_vcpkg|Win32">
+      <Configuration>Release_vcpkg</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release_vcpkg|x64">
+      <Configuration>Release_vcpkg</Configuration>
+      <Platform>x64</Platform>
     </ProjectConfiguration>
     <ProjectConfiguration Include="Release|Win32">
       <Configuration>Release</Configuration>
@@ -105,7 +121,20 @@
     <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_vcpkg|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_vcpkg|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>
@@ -118,7 +147,20 @@
     <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_vcpkg|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_vcpkg|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>
@@ -133,20 +175,38 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug_vcpkg|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release_vcpkg|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug_vcpkg|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release_vcpkg|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_vcpkg|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_vcpkg|Win32'">
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -154,7 +214,17 @@
     <OutDir>..\..\lib\$(Configuration)\</OutDir>
     <IntDir>tmp\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_vcpkg|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>..\..\lib\$(Configuration)\</OutDir>
+    <IntDir>tmp\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>..\..\lib\$(Configuration)\</OutDir>
+    <IntDir>tmp\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_vcpkg|x64'">
     <LinkIncremental>false</LinkIncremental>
     <OutDir>..\..\lib\$(Configuration)\</OutDir>
     <IntDir>tmp\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
@@ -174,7 +244,41 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug_vcpkg|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+    </ClCompile>
+    <Link>
+      <SubSystem>
+      </SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+    </ClCompile>
+    <Link>
+      <SubSystem>
+      </SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release_vcpkg|Win32'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -210,7 +314,45 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug_vcpkg|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <AdditionalIncludeDirectories>..\..\include\VocalTractLabBackend;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp14</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>
+      </SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <AdditionalIncludeDirectories>..\..\include\VocalTractLabBackend;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp14</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>
+      </SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release_vcpkg|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>

--- a/build/msw/VocalTractLabBackend.vcxproj
+++ b/build/msw/VocalTractLabBackend.vcxproj
@@ -1,25 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
-    <ProjectConfiguration Include="Debug_vcpkg|Win32">
-      <Configuration>Debug_vcpkg</Configuration>
-      <Platform>Win32</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Debug_vcpkg|x64">
-      <Configuration>Debug_vcpkg</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
       <Platform>Win32</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Release_vcpkg|Win32">
-      <Configuration>Release_vcpkg</Configuration>
-      <Platform>Win32</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Release_vcpkg|x64">
-      <Configuration>Release_vcpkg</Configuration>
-      <Platform>x64</Platform>
     </ProjectConfiguration>
     <ProjectConfiguration Include="Release|Win32">
       <Configuration>Release</Configuration>
@@ -121,20 +105,7 @@
     <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_vcpkg|Win32'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_vcpkg|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>
@@ -147,20 +118,7 @@
     <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_vcpkg|x64'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_vcpkg|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>
@@ -175,38 +133,20 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug_vcpkg|Win32'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release_vcpkg|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug_vcpkg|x64'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release_vcpkg|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_vcpkg|Win32'">
-    <LinkIncremental>true</LinkIncremental>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <LinkIncremental>false</LinkIncremental>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_vcpkg|Win32'">
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -214,17 +154,7 @@
     <OutDir>..\..\lib\$(Configuration)\</OutDir>
     <IntDir>tmp\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_vcpkg|x64'">
-    <LinkIncremental>true</LinkIncremental>
-    <OutDir>..\..\lib\$(Configuration)\</OutDir>
-    <IntDir>tmp\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <LinkIncremental>false</LinkIncremental>
-    <OutDir>..\..\lib\$(Configuration)\</OutDir>
-    <IntDir>tmp\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_vcpkg|x64'">
     <LinkIncremental>false</LinkIncremental>
     <OutDir>..\..\lib\$(Configuration)\</OutDir>
     <IntDir>tmp\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
@@ -244,41 +174,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug_vcpkg|Win32'">
-    <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
-      <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-    </ClCompile>
-    <Link>
-      <SubSystem>
-      </SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-    </Link>
-  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
-      <FunctionLevelLinking>true</FunctionLevelLinking>
-      <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-    </ClCompile>
-    <Link>
-      <SubSystem>
-      </SubSystem>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <OptimizeReferences>true</OptimizeReferences>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release_vcpkg|Win32'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -314,45 +210,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug_vcpkg|x64'">
-    <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
-      <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>..\..\include\VocalTractLabBackend;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpp14</LanguageStandard>
-    </ClCompile>
-    <Link>
-      <SubSystem>
-      </SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-    </Link>
-  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
-      <FunctionLevelLinking>true</FunctionLevelLinking>
-      <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>..\..\include\VocalTractLabBackend;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpp14</LanguageStandard>
-    </ClCompile>
-    <Link>
-      <SubSystem>
-      </SubSystem>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <OptimizeReferences>true</OptimizeReferences>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release_vcpkg|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>

--- a/build/msw/VtlApiTests.vcxproj
+++ b/build/msw/VtlApiTests.vcxproj
@@ -71,6 +71,7 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -102,6 +103,7 @@
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/build/msw/VtlBackendTests.vcxproj
+++ b/build/msw/VtlBackendTests.vcxproj
@@ -63,6 +63,7 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -79,6 +80,7 @@
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <AdditionalIncludeDirectories>..\..\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -93,6 +95,7 @@
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -110,6 +113,7 @@
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <AdditionalIncludeDirectories>..\..\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/include/VocalTractLabApi/VocalTractLabApi.h
+++ b/include/VocalTractLabApi/VocalTractLabApi.h
@@ -472,6 +472,7 @@ C_EXPORT int vtlSegmentSequenceToGesturalScore(const char *segFileName, const ch
 
 // ****************************************************************************
 // This function directly converts a gestural score to an audio signal or file.
+//
 // Parameters:
 // o gesFileName (in): Name of the gestural score file to synthesize.
 // o wavFileName (in): Name of the audio file with the resulting speech signal.
@@ -501,7 +502,7 @@ C_EXPORT int vtlGesturalScoreToAudio(const char* gesFileName, const char* wavFil
 // This function directly converts a gestural score to a tract sequence file.
 // The latter is a text file containing the parameters of the vocal fold and 
 // vocal tract models in steps of 5 ms.
-
+//
 // Parameters:
 // o gesFileName (in): Name of the gestural score file to convert.
 // o tractSequenceFileName (in): Name of the tract sequence file.
@@ -520,6 +521,7 @@ C_EXPORT int vtlGesturalScoreToTractSequence(const char* gesFileName,
 
 // ****************************************************************************
 // This function gets the duration from a gestural score.
+//
 // Parameters:
 // o gesFileName (in): Name of the gestural score file.
 // o audioFileDuration (out): The number of audio samples, the audio file would
@@ -542,6 +544,7 @@ C_EXPORT int vtlGetGesturalScoreDuration(const char* gesFileName, int* numAudioS
 
 // ****************************************************************************
 // This function converts a tract sequence file into an audio signal or file.
+//
 // Parameters:
 // o tractSequenceFileName (in): Name of the tract sequence file to synthesize.
 // o wavFileName (in): Name of the audio file with the resulting speech signal.
@@ -565,10 +568,11 @@ C_EXPORT int vtlTractSequenceToAudio(const char* tractSequenceFileName,
 
 
 // ****************************************************************************
-// This function calculates  and exports Ema Points.
+// This function calculates and exports EMA points.
+//
 // Parameters:
 // o gestureFileName: Name of the gestural score file to synthesize.
-// o emaFileName: Name of a text file to which the sequence of Ema Point Coordinates
+// o emaFileName: Name of a text file to which the sequence of EMA point Coordinates
 //      and other feedback data will be written.
 //
 // The return value is 0 if successful, and otherwise an error code >= 1.
@@ -583,26 +587,26 @@ C_EXPORT int vtlGesturalScoreToEma(const char *gestureFileName, const char *emaF
 
 
 // ****************************************************************************
-// Calculate and export selected Ema points and mesh data with a given sequence
+// Calculate and export selected EMA points and mesh data with a given sequence
 // of vocal tract model states and glottis model states. For each frame in
 // the incoming model, a 3D-mesh of the vocal tract is calculated and exported
-// in an obj.-file and a corresponding .mtl file. The files' names consist of
-// the name handed in in "fileName" and the number of the current frame. These
+// in an .obj-file and a corresponding .mtl file. The files' names consist of
+// the name handed in "fileName" and the number of the current frame. These
 // files are stored in a subfolder "fileName-meshes" of the given directory
-// "filePath". The Ema points are exported into a .txt file named
+// "filePath". The EMA points are exported into a .txt file named
 // "fileName-ema" in the directory "filePath". It contains the time of the
-// frame and the 3D-coordinates of all selected Ema points per frame in a row.
+// frame and the 3D-coordinates of all selected EMA points per frame in a row.
 //
-// Parameters (in):
+// Parameters in:
 // o tractParams: Is a concatenation of vocal tract parameter vectors
 //     with the total length of (numVocalTractParams*numFrames) elements.
 // o glottisParams: Is a concatenation of glottis parameter vectors
 //     with the total length of (numGlottisParams*numFrames) elements.
 // o numTractParams: length of tractParams
 // o numGlottisParams: length of glottisParams
-// o numFrames: Amount of frames the model data contain
-// o numEmaPoints: number of selected Ema Points
-// o surf: Array with indices of surfaces of selected Ema Points
+// o numFrames: number of frames the model data contain
+// o numEmaPoints: number of selected EMA points
+// o surf: Array with indices of surfaces of selected EMA points
 //            (UPPER_TEETH = 0, LOWER_TEETH = 1, UPPER_COVER = 2,
 //             LOWER_COVER = 3, UPPER_LIP = 4, LOWER_LIP = 5,
 //             PALATE = 6, MANDIBLE = 7, LOWER_TEETH_ORIGINAL = 8,
@@ -616,15 +620,15 @@ C_EXPORT int vtlGesturalScoreToEma(const char *gestureFileName, const char *emaF
 //             RIGHT_COVER = 24, UVULA_ORIGINAL = 25, UVULA = 26,
 //             UVULA_TWOSIDE = 27, EPIGLOTTIS_ORIGINAL = 28,
 //             EPIGLOTTIS = 29, EPIGLOTTIS_TWOSIDE = 30)
-// o vert: Array with index of vertices of selected Ema Points
-//            (Predefined Ema Point Vertex Indices:
+// o vert: Array with index of vertices of selected EMA points
+//            (Predefined EMA point vertex indices:
 //             Tongue Back (TB) = 115
 //             Tongue Middle (TM) = 225
 //             Tongue Tip (TT) = 335
 //             Upper Lip (UL) = 89
 //             Lower Lip (LL) = 89
 //             Lower Cover (JAW) = 148)
-// o filePath: path leading to the directory where ema and mesh files shall be stored.
+// o filePath: path leading to the directory where EMA and mesh files shall be stored.
 // o fileName: name of all exported datasets
 //
 // The return value is 0 if successful, and otherwise an error code >= 1.
@@ -637,9 +641,9 @@ C_EXPORT int vtlGesturalScoreToEma(const char *gestureFileName, const char *emaF
 // 5: vertex index of a selected EmaPoint exceeds possible range
 // 6: filePath is not valid
 // 7: mesh folder already exist: prevents overwriting
-// 8: ema file already exists: prevents overwriting
-// 9: ema file could not be opened
-// 10: API already initialized
+// 8: EMA file already exists: prevents overwriting
+// 9: EMA file could not be opened
+// 10: API has not been initialized
 // ****************************************************************************
 
 C_EXPORT int vtlTractSequenceToEmaAndMesh(double *tractParams, double *glottisParams, int numTractParams, int numGlottisParams, int numFrames, int numEmaPoints, int *surf, int *vert, const char *filePath, const char *fileName);
@@ -648,9 +652,10 @@ C_EXPORT int vtlTractSequenceToEmaAndMesh(double *tractParams, double *glottisPa
 // ****************************************************************************
 // This function calculates a sequence of vocal tract model states and
 // glottis model states from a gestural score and hands them over to vtlTractandGlottisToEma().
-// Parameters (in):
+//
+// Parameters in:
 // o gestureFileName: Name of the gestural score file to synthesize.
-// o filePath: path leading to the directory where ema and mesh files shall be stored.
+// o filePath: path leading to the directory where EMA and mesh files shall be stored.
 // o fileName: name of all exported datasets
 //
 // The return value is 0 if successful, and otherwise an error code >= 1.

--- a/include/VocalTractLabApi/VocalTractLabApi.h
+++ b/include/VocalTractLabApi/VocalTractLabApi.h
@@ -22,7 +22,7 @@
 // ****************************************************************************
 // This file defines the entry point for the DLL application, and the functions
 // defined here are C-compatible so that they can be used with the 
-// MATLAB shared library interface.
+// MATLAB and Python shared library interface.
 // ****************************************************************************
 
 // Make an extern "C" section so that the functions can be accessed from Matlab
@@ -563,6 +563,105 @@ C_EXPORT int vtlGetGesturalScoreDuration(const char* gesFileName, int* numAudioS
 C_EXPORT int vtlTractSequenceToAudio(const char* tractSequenceFileName,
   const char* wavFileName, double* audio, int* numSamples);
 
+
+// ****************************************************************************
+// This function calculates  and exports Ema Points.
+// Parameters:
+// o gestureFileName: Name of the gestural score file to synthesize.
+// o emaFileName: Name of a text file to which the sequence of Ema Point Coordinates
+//      and other feedback data will be written.
+//
+// The return value is 0 if successful, and otherwise an error code >= 1.
+// Error codes:
+// 0: success.
+// 1: The API was not initialized.
+// 2: Loading the gestural score file failed.
+// 3: Values in the gestural score files are out of range.
+// ****************************************************************************
+
+C_EXPORT int vtlGesturalScoreToEma(const char *gestureFileName, const char *emaFileName);
+
+
+// ****************************************************************************
+// Calculate and export selected Ema points and mesh data with a given sequence
+// of vocal tract model states and glottis model states. For each frame in
+// the incoming model, a 3D-mesh of the vocal tract is calculated and exported
+// in an obj.-file and a corresponding .mtl file. The files' names consist of
+// the name handed in in "fileName" and the number of the current frame. These
+// files are stored in a subfolder "fileName-meshes" of the given directory
+// "filePath". The Ema points are exported into a .txt file named
+// "fileName-ema" in the directory "filePath". It contains the time of the
+// frame and the 3D-coordinates of all selected Ema points per frame in a row.
+//
+// Parameters (in):
+// o tractParams: Is a concatenation of vocal tract parameter vectors
+//     with the total length of (numVocalTractParams*numFrames) elements.
+// o glottisParams: Is a concatenation of glottis parameter vectors
+//     with the total length of (numGlottisParams*numFrames) elements.
+// o numTractParams: length of tractParams
+// o numGlottisParams: length of glottisParams
+// o numFrames: Amount of frames the model data contain
+// o numEmaPoints: number of selected Ema Points
+// o surf: Array with indices of surfaces of selected Ema Points
+//            (UPPER_TEETH = 0, LOWER_TEETH = 1, UPPER_COVER = 2,
+//             LOWER_COVER = 3, UPPER_LIP = 4, LOWER_LIP = 5,
+//             PALATE = 6, MANDIBLE = 7, LOWER_TEETH_ORIGINAL = 8,
+//             LOW_VELUM = 9, MID_VELUM = 10, HIGH_VELUM = 11,
+//             NARROW_LARYNX_FRONT = 12, NARROW_LARYNX_BACK = 13,
+//             WIDE_LARYNX_FRONT = 14, WIDE_LARYNX_BACK = 15,
+//             TONGUE = 16, UPPER_COVER_TWOSIDE = 17,
+//             LOWER_COVER_TWOSIDE = 18, UPPER_TEETH_TWOSIDE = 19,
+//             LOWER_TEETH_TWOSIDE = 20, UPPER_LIP_TWOSIDE = 21,
+//             LOWER_LIP_TWOSIDE = 22, LEFT_COVER = 23,
+//             RIGHT_COVER = 24, UVULA_ORIGINAL = 25, UVULA = 26,
+//             UVULA_TWOSIDE = 27, EPIGLOTTIS_ORIGINAL = 28,
+//             EPIGLOTTIS = 29, EPIGLOTTIS_TWOSIDE = 30)
+// o vert: Array with index of vertices of selected Ema Points
+//            (Predefined Ema Point Vertex Indices:
+//             Tongue Back (TB) = 115
+//             Tongue Middle (TM) = 225
+//             Tongue Tip (TT) = 335
+//             Upper Lip (UL) = 89
+//             Lower Lip (LL) = 89
+//             Lower Cover (JAW) = 148)
+// o filePath: path leading to the directory where ema and mesh files shall be stored.
+// o fileName: name of all exported datasets
+//
+// The return value is 0 if successful, and otherwise an error code >= 1.
+// Error codes:
+// 0: success.
+// 1: numEmaPoints <= 0
+// 2: surf == NULL
+// 3: vert == NULL
+// 4: surface index of a selected EmaPoints exceeds 30
+// 5: vertex index of a selected EmaPoint exceeds possible range
+// 6: filePath is not valid
+// 7: mesh folder already exist: prevents overwriting
+// 8: ema file already exists: prevents overwriting
+// 9: ema file could not be opened
+// 10: API already initialized
+// ****************************************************************************
+
+C_EXPORT int vtlTractSequenceToEmaAndMesh(double *tractParams, double *glottisParams, int numTractParams, int numGlottisParams, int numFrames, int numEmaPoints, int *surf, int *vert, const char *filePath, const char *fileName);
+
+
+// ****************************************************************************
+// This function calculates a sequence of vocal tract model states and
+// glottis model states from a gestural score and hands them over to vtlTractandGlottisToEma().
+// Parameters (in):
+// o gestureFileName: Name of the gestural score file to synthesize.
+// o filePath: path leading to the directory where ema and mesh files shall be stored.
+// o fileName: name of all exported datasets
+//
+// The return value is 0 if successful, and otherwise an error code >= 1.
+// Error codes:
+// 0: success.
+// 1: The API was not initialized.
+// 2: Loading the gestural score file failed.
+// 3: Values in the gestural score files are out of range.
+// ****************************************************************************
+
+C_EXPORT int vtlGesturalScoreToEmaAndMesh(const char *gestureFileName, const char *filePath, const char *fileName);
 
 // ****************************************************************************
 

--- a/src/VocalTractLabApi/VocalTractLabApi.cpp
+++ b/src/VocalTractLabApi/VocalTractLabApi.cpp
@@ -1794,7 +1794,7 @@ int vtlGesturalScoreToEma(const char *gestureFileName, const char *emaFileName)
 // Calculate and export selected EMA points and mesh data with a given sequence
 // of vocal tract model states and glottis model states. For each frame in
 // the incoming model, a 3D-mesh of the vocal tract is calculated and exported
-// in an obj.-file and a corresponding .mtl file. The files' names consist of
+// in an .obj-file and a corresponding .mtl file. The files' names consist of
 // the name handed in "fileName" and the number of the current frame. These
 // files are stored in a subfolder "fileName-meshes" of the given directory
 // "filePath". The EMA points are exported into a .txt file named

--- a/src/VocalTractLabApi/VocalTractLabApi.cpp
+++ b/src/VocalTractLabApi/VocalTractLabApi.cpp
@@ -39,7 +39,7 @@
 
 #include <iostream>
 #include <fstream>
-#include <iomanip>  // for `setprecision`
+#include <iomanip>  // for 'setprecision'
 #include <filesystem>
 namespace fs = std::filesystem;
 
@@ -1258,6 +1258,7 @@ int vtlSegmentSequenceToGesturalScore(const char *segFileName, const char *gesFi
 
 // ****************************************************************************
 // This function directly converts a gestural score to an audio signal or file.
+//
 // Parameters:
 // o gesFileName (in): Name of the gestural score file to synthesize.
 // o wavFileName (in): Name of the audio file with the resulting speech signal.
@@ -1380,7 +1381,7 @@ int vtlGesturalScoreToAudio(const char *gesFileName, const char *wavFileName,
 // This function directly converts a gestural score to a tract sequence file.
 // The latter is a text file containing the parameters of the vocal fold and 
 // vocal tract models in steps of about 2.5 ms.
-
+//
 // Parameters:
 // o gesFileName (in): Name of the gestural score file to convert.
 // o tractSequenceFileName (in): Name of the tract sequence file.
@@ -1450,6 +1451,7 @@ int vtlGesturalScoreToTractSequence(const char* gesFileName, const char* tractSe
 
 // ****************************************************************************
 // This function gets the duration from a gestural score.
+//
 // Parameters:
 // o gesFileName (in): Name of the gestural score file.
 // o audioFileDuration (out): The number of audio samples, the audio file would
@@ -1518,6 +1520,7 @@ int vtlGetGesturalScoreDuration(const char* gesFileName, int* numAudioSamples, i
 
 // ****************************************************************************
 // This function converts a tract sequence file into an audio signal or file.
+//
 // Parameters:
 // o tractSequenceFileName (in): Name of the tract sequence file to synthesize.
 // o wavFileName (in): Name of the audio file with the resulting speech signal.
@@ -1610,10 +1613,11 @@ int vtlTractSequenceToAudio(const char* tractSequenceFileName, const char* wavFi
 
 
 // ****************************************************************************
-// This function calculates  and exports Ema Points.
+// This function calculates and exports EMA points.
+//
 // Parameters:
 // o gestureFileName: Name of the gestural score file to synthesize.
-// o emaFileName: Name of a text file to which the sequence of Ema Point Coordinates
+// o emaFileName: Name of a text file to which the sequence of EMA point coordinates
 //      and other feedback data will be written.
 //
 // The return value is 0 if successful, and otherwise an error code >= 1.
@@ -1669,7 +1673,7 @@ int vtlGesturalScoreToEma(const char *gestureFileName, const char *emaFileName)
   gesturalScore->calcCurves();
 
   // ****************************************************************
-  // Open the text file for the ema points.
+  // Open the text file for the EMA points.
   // ****************************************************************
 
   ofstream emaFile;
@@ -1678,7 +1682,7 @@ int vtlGesturalScoreToEma(const char *gestureFileName, const char *emaFileName)
     emaFile.open(emaFileName);
     if (emaFile.is_open() == false)
     {
-      printf("Warning in vtlGesturalScoreToEma(): The ema file could not be opened!\n");
+      printf("Warning in vtlGesturalScoreToEma(): The EMA file could not be opened!\n");
     }
     else
     {
@@ -1720,7 +1724,7 @@ int vtlGesturalScoreToEma(const char *gestureFileName, const char *emaFileName)
     }
 
     // ****************************************************************
-    // Write the ema points in the file (every 0.005 sec).
+    // Write the EMA points in the file (every 0.005 sec).
     // ****************************************************************
 
     const double EMA_SAMPLING_RATE_HZ = 200.0;
@@ -1767,7 +1771,7 @@ int vtlGesturalScoreToEma(const char *gestureFileName, const char *emaFileName)
     vocalTract->calculateAll();
 
     // ****************************************************************
-    // Close the file with the ema points.
+    // Close the file with the EMA points.
     // ****************************************************************
 
     if (emaFile.is_open())
@@ -1787,26 +1791,26 @@ int vtlGesturalScoreToEma(const char *gestureFileName, const char *emaFileName)
 
 
 // ****************************************************************************
-// Calculate and export selected Ema points and mesh data with a given sequence
+// Calculate and export selected EMA points and mesh data with a given sequence
 // of vocal tract model states and glottis model states. For each frame in
 // the incoming model, a 3D-mesh of the vocal tract is calculated and exported
 // in an obj.-file and a corresponding .mtl file. The files' names consist of
-// the name handed in in "fileName" and the number of the current frame. These
+// the name handed in "fileName" and the number of the current frame. These
 // files are stored in a subfolder "fileName-meshes" of the given directory
-// "filePath". The Ema points are exported into a .txt file named
+// "filePath". The EMA points are exported into a .txt file named
 // "fileName-ema" in the directory "filePath". It contains the time of the
-// frame and the 3D-coordinates of all selected Ema points per frame in a row.
+// frame and the 3D-coordinates of all selected EMA points per frame in a row.
 //
-// Parameters (in):
+// Parameters in:
 // o tractParams: Is a concatenation of vocal tract parameter vectors
 //     with the total length of (numVocalTractParams*numFrames) elements.
 // o glottisParams: Is a concatenation of glottis parameter vectors
 //     with the total length of (numGlottisParams*numFrames) elements.
 // o numTractParams: length of tractParams
 // o numGlottisParams: length of glottisParams
-// o numFrames: Amount of frames the model data contain
-// o numEmaPoints: number of selected Ema Points
-// o surf: Array with indices of surfaces of selected Ema Points
+// o numFrames: number of frames the model data contain
+// o numEmaPoints: number of selected EMA points
+// o surf: Array with indices of surfaces of selected EMA points
 //            (UPPER_TEETH = 0, LOWER_TEETH = 1, UPPER_COVER = 2,
 //             LOWER_COVER = 3, UPPER_LIP = 4, LOWER_LIP = 5,
 //             PALATE = 6, MANDIBLE = 7, LOWER_TEETH_ORIGINAL = 8,
@@ -1820,15 +1824,15 @@ int vtlGesturalScoreToEma(const char *gestureFileName, const char *emaFileName)
 //             RIGHT_COVER = 24, UVULA_ORIGINAL = 25, UVULA = 26,
 //             UVULA_TWOSIDE = 27, EPIGLOTTIS_ORIGINAL = 28,
 //             EPIGLOTTIS = 29, EPIGLOTTIS_TWOSIDE = 30)
-// o vert: Array with index of vertices of selected Ema Points
-//            (Predefined Ema Point Vertex Indices:
+// o vert: Array with index of vertices of selected EMA points
+//            (Predefined EMA point vertex indices:
 //             Tongue Back (TB) = 115
 //             Tongue Middle (TM) = 225
 //             Tongue Tip (TT) = 335
 //             Upper Lip (UL) = 89
 //             Lower Lip (LL) = 89
 //             Lower Cover (JAW) = 148)
-// o filePath: path leading to the directory where ema and mesh files shall be stored.
+// o filePath: path leading to the directory where EMA and mesh files shall be stored.
 // o fileName: name of all exported datasets
 //
 // The return value is 0 if successful, and otherwise an error code >= 1.
@@ -1841,29 +1845,29 @@ int vtlGesturalScoreToEma(const char *gestureFileName, const char *emaFileName)
 // 5: vertex index of a selected EmaPoint exceeds possible range
 // 6: filePath is not valid
 // 7: mesh folder already exist: prevents overwriting
-// 8: ema file already exists: prevents overwriting
-// 9: ema file could not be opened
-// 10: API already initialized
+// 8: EMA file already exists: prevents overwriting
+// 9: EMA file could not be opened
+// 10: API has not been initialized
 // ****************************************************************************
 
 int vtlTractSequenceToEmaAndMesh(double *tractParams, double *glottisParams, int numTractParams, int numGlottisParams, int numFrames, int numEmaPoints, int *surf, int *vert, const char *filePath, const char *fileName)
 {
-  // Return if no Ema Point are selected
+  // Return if no EMA point is selected
   if (numEmaPoints <= 0)
   {
-    printf("Error in vtlModelToOptionalEmaAndMesh(): numEmaPoints <= 0");
+    printf("Error in vtlTractSequenceToEmaAndMesh(): numEmaPoints <= 0");
     return 1;
   }
 
   if (surf == NULL)
   {
-    printf("Error in vtlModelToOptionalEmaAndMesh(): surf == NULL");
+    printf("Error in vtlTractSequenceToEmaAndMesh(): surf == NULL");
     return 2;
   }
 
   if (vert == NULL)
   {
-    printf("Error in vtlModelToOptionalEmaAndMesh(): vert == NULL");
+    printf("Error in vtlTractSequenceToEmaAndMesh(): vert == NULL");
     return 3;
   }
 
@@ -1874,14 +1878,14 @@ int vtlTractSequenceToEmaAndMesh(double *tractParams, double *glottisParams, int
   }
 
   // ****************************************************************
-  // Create mesh and ema file paths
+  // Create mesh and EMA file paths
   // ****************************************************************
 
   fs::path path = filePath;
 
   if (!fs::exists(path))
   {
-    printf("Error in vtlModelToOptionalEmaAndMesh(): filePath doesn't exist");
+    printf("Error in vtlTractSequenceToEmaAndMesh(): filePath doesn't exist");
     return 6;
   }
 
@@ -1902,7 +1906,7 @@ int vtlTractSequenceToEmaAndMesh(double *tractParams, double *glottisParams, int
 
   if (fs::exists(objFilePath))
   {
-    printf("Error in vtlModelToOptionalEmaAndMesh(): Mesh-Folder already exists");
+    printf("Error in vtlTractSequenceToEmaAndMesh(): Mesh-Folder already exists");
     return 7;
   }
   // create mesh-directory
@@ -1961,12 +1965,12 @@ int vtlTractSequenceToEmaAndMesh(double *tractParams, double *glottisParams, int
   {
     if (surf[e] > 30)
     {
-      printf("Error in vtlModelToOptionalEmaAndMesh(): Surface at surf[%d] out of range, maximal Surface is %d\n", e, 30);
+      printf("Error in vtlTractSequenceToEmaAndMesh(): Surface at surf[%d] out of range, maximal Surface is %d\n", e, 30);
       return 4;
     }
     if (vert[e] > maxVertex[e])
     {
-      printf("Error in vtlModelToOptionalEmaAndMesh(): Vertex at vert[%d] out of range, maximal Vertex of chosen Surface %d is %d\n", e, surf[e],maxVertex[e]);
+      printf("Error in vtlTractSequenceToEmaAndMesh(): Vertex at vert[%d] out of range, maximal Vertex of chosen Surface %d is %d\n", e, surf[e],maxVertex[e]);
       return 5;
     }
   }
@@ -1974,7 +1978,7 @@ int vtlTractSequenceToEmaAndMesh(double *tractParams, double *glottisParams, int
   ofstream emaFile;
   if (fs::exists(emaFilePath))
   {
-    printf("Error in vtlModelToOptionalEmaAndMesh(): EMA file already exists");
+    printf("Error in vtlTractSequenceToEmaAndMesh(): EMA file already exists");
     return 8;
   }
 
@@ -1983,14 +1987,14 @@ int vtlTractSequenceToEmaAndMesh(double *tractParams, double *glottisParams, int
     emaFile.open(emaFilePath.string());
     if (emaFile.is_open() == false)
     {
-      printf("Warning in vtlModelToOptionalEmaAndMesh(): The Ema file could not be opened!\n");
+      printf("Warning in vtlTractSequenceToEmaAndMesh(): The Ema file could not be opened!\n");
       return 9;
 
     }
     else
     {
       // ****************************************************************
-      // Write the Header in Ema file
+      // Write the Header in EMA file
       // ****************************************************************
       emaFile << "time(s) ";
 
@@ -2026,7 +2030,7 @@ int vtlTractSequenceToEmaAndMesh(double *tractParams, double *glottisParams, int
       }
       vocalTract->calculateAll();
 
-      // Calculate coordinates for each selected Ema Points
+      // Calculate coordinates for each selected EMA points
       for (e = 0; e < numEmaPoints; e++)
       {
         s = &vocalTract->surface[surf[e]];
@@ -2046,7 +2050,7 @@ int vtlTractSequenceToEmaAndMesh(double *tractParams, double *glottisParams, int
     }
 
     // ****************************************************************
-    // Close the file with the ema points.
+    // Close the file with the EMA points.
     // ****************************************************************
     if (emaFile.is_open())
     {
@@ -2060,9 +2064,10 @@ int vtlTractSequenceToEmaAndMesh(double *tractParams, double *glottisParams, int
 // ****************************************************************************
 // This function calculates a sequence of vocal tract model states and
 // glottis model states from a gestural score and hands them over to vtlTractandGlottisToEma().
-// Parameters (in):
+//
+// Parameters in:
 // o gestureFileName: Name of the gestural score file to synthesize.
-// o filePath: path leading to the directory where ema and mesh files shall be stored.
+// o filePath: path leading to the directory where EMA and mesh files shall be stored.
 // o fileName: name of all exported datasets
 //
 // The return value is 0 if successful, and otherwise an error code >= 1.
@@ -2152,10 +2157,10 @@ int vtlGesturalScoreToEmaAndMesh(const char *gestureFileName, const char *filePa
 
   delete gesturalScore;
 
-  int surf[] = {16,16,16};   // Surface of selected Ema Point
-  int vertex[] = {115,225,335};  // Vertex Index of selected Ema Point
+  int surf[] = {16,16,16};   // Surface of selected EMA point
+  int vertex[] = {115,225,335};  // Vertex Index of selected EMA point
 
-  // Call of vtlModelToOptionalEmaAndMesh could also be done from outside!
+  // Call of vtlTractSequenceToEmaAndMesh could also be done from outside!
   return vtlTractSequenceToEmaAndMesh(tractParams.data(), glottisParams.data(), numTractParams, numGlottisParams, numFrames, 3, surf, vertex, filePath, fileName);
 }
 

--- a/src/VocalTractLabApi/VocalTractLabApi.cpp
+++ b/src/VocalTractLabApi/VocalTractLabApi.cpp
@@ -187,6 +187,29 @@ int vtlInitialize(const char *speakerFileName)
 
 
 // ****************************************************************************
+// Save the current speaker information (vocal tract and glottis shape) in
+// a speaker file (e.g., "JD3.speaker")
+// Return values:
+// 0: success.
+// 1: Saving the speaker file failed.
+// ****************************************************************************
+
+int vtlSaveSpeaker(const char* speakerFileName)
+{
+    Speaker speaker(vocalTract, { std::begin(glottis), std::end(glottis) }, selectedGlottis);
+    try
+    {
+        speaker.save(speakerFileName);
+        return 0;
+    }
+    catch (std::exception&)
+    {
+        return 1;
+    }
+}
+
+
+// ****************************************************************************
 // Clean up the memory and shut down the synthesizer.
 // Return values:
 // 0: success.
@@ -2132,22 +2155,6 @@ int vtlGesturalScoreToEmaAndMesh(const char *gestureFileName, const char *filePa
 
   // Call of vtlModelToOptionalEmaAndMesh could also be done from outside!
   return vtlTractSequenceToEmaAndMesh(tractParams, glottisParams, numTractParams, numGlottisParams, numFrames, 3, surf, vertex, filePath, fileName);
-}
-
-
-// ****************************************************************************
-int vtlSaveSpeaker(const char* speakerFileName)
-{
-    Speaker speaker(vocalTract, { std::begin(glottis), std::end(glottis) }, selectedGlottis);
-    try
-    {
-        speaker.save(speakerFileName);
-        return 0;
-    }
-    catch (std::exception&)
-    {
-        return 1;
-    }    
 }
 
 // ****************************************************************************

--- a/src/VocalTractLabApi/VocalTractLabApi.cpp
+++ b/src/VocalTractLabApi/VocalTractLabApi.cpp
@@ -283,6 +283,8 @@ void vtlGetVersion(char *version)
 // o The number of supraglottal tube sections.
 // o The number of vocal tract model parameters.
 // o The number of glottis model parameters.
+// o The number of audio samples per tract state.
+// o The internal sampling rate.
 //
 // Function return value:
 // 0: success.

--- a/src/VocalTractLabApi/VocalTractLabApi.cpp
+++ b/src/VocalTractLabApi/VocalTractLabApi.cpp
@@ -1937,14 +1937,14 @@ int vtlTractSequenceToEmaAndMesh(double *tractParams, double *glottisParams, int
         "EPIGLOTTIS",
         "EPIGLOTTIS_TWOSIDE"};
 
-  double glotParams[numGlottisParams];
+  std::vector<double> glotParams(numGlottisParams, 0.0);
 
   Point3D P(0.0, 0.0, 0.0);
 
   Surface *s = NULL;
 
   // Store maximal index of Vertices for each surface in surf[]
-  int maxVertex[numEmaPoints];
+  std::vector<int> maxVertex(numEmaPoints, 0);
   int  i,e;
 
   //Calculate max Vertex for each surface in surf (Compare with VocalTract::getEmaSurfaceVertexRange())
@@ -2040,7 +2040,7 @@ int vtlTractSequenceToEmaAndMesh(double *tractParams, double *glottisParams, int
         }
       }
 
-      vocalTract->saveAsObjFile(objFileName, true); // write .obj files of current vocal tract
+      vocalTract->saveAsObjFile(objFileName.string(), true); // write .obj files of current vocal tract
       emaFile << endl;
 
     }
@@ -2119,12 +2119,12 @@ int vtlGesturalScoreToEmaAndMesh(const char *gestureFileName, const char *filePa
   int numTractParams = VocalTract::NUM_PARAMS;
   int numGlottisParams = (int)glottis[selectedGlottis]->controlParam.size();
 
-  double storeTractParams[numTractParams];
-  double storeGlottisParams[numGlottisParams];
+  std::vector<double> storeTractParams(numTractParams, 0.0);
+  std::vector<double> storeGlottisParams(numGlottisParams, 0.0);
 
 
-  double tractParams[numFrames * numTractParams];
-  double glottisParams[numFrames * numGlottisParams];
+  std::vector<double> tractParams(numFrames * numTractParams, 0.0);
+  std::vector<double> glottisParams(numFrames * numGlottisParams, 0.0);
 
   // ************************************************************************
   // Extract glottis and tract params here
@@ -2133,7 +2133,7 @@ int vtlGesturalScoreToEmaAndMesh(const char *gestureFileName, const char *filePa
   for (f=0; f < numFrames; f++)
   {
     t_s = (double)f / (double)EMA_SAMPLING_RATE_HZ;
-    gesturalScore->getParams(t_s, storeTractParams, storeGlottisParams);
+    gesturalScore->getParams(t_s, storeTractParams.data(), storeGlottisParams.data());
 
     for (i = 0; i < numTractParams; i++)
     {
@@ -2156,7 +2156,7 @@ int vtlGesturalScoreToEmaAndMesh(const char *gestureFileName, const char *filePa
   int vertex[] = {115,225,335};  // Vertex Index of selected Ema Point
 
   // Call of vtlModelToOptionalEmaAndMesh could also be done from outside!
-  return vtlTractSequenceToEmaAndMesh(tractParams, glottisParams, numTractParams, numGlottisParams, numFrames, 3, surf, vertex, filePath, fileName);
+  return vtlTractSequenceToEmaAndMesh(tractParams.data(), glottisParams.data(), numTractParams, numGlottisParams, numFrames, 3, surf, vertex, filePath, fileName);
 }
 
 // ****************************************************************************

--- a/src/VocalTractLabApi/VocalTractLabApi.def
+++ b/src/VocalTractLabApi/VocalTractLabApi.def
@@ -1,7 +1,6 @@
 LIBRARY
 EXPORTS
 vtlInitialize
-vtlSaveSpeaker
 vtlClose
 vtlCalcTongueRootAutomatically
 vtlGetVersion
@@ -25,3 +24,7 @@ vtlGesturalScoreToAudio
 vtlGesturalScoreToTractSequence
 vtlGetGesturalScoreDuration
 vtlTractSequenceToAudio
+vtlGesturalScoreToEma
+vtlGesturalScoreToEmaAndMesh
+vtlTractSequenceToEmaAndMesh
+vtlSaveSpeaker

--- a/test/VtlApiTests.cpp
+++ b/test/VtlApiTests.cpp
@@ -22,10 +22,10 @@ const char* wavFile = "test/resources/example01.wav";
 TEST(ApiTest, Version) 
 {
     std::cout << std::filesystem::current_path() << std::endl;
-	char version[32];
+	char version[64];
 	vtlGetVersion(version);
 	std::string s(version);
-	EXPECT_EQ(s, std::string(__DATE__));
+	EXPECT_EQ(s, std::string("API 2.4.1 ") + std::string(__DATE__));
 }
 
 TEST(ApiTest, Constants)


### PR DESCRIPTION
These function adds export of virtual electromagnetic articulography (EMA) points  and export of mesh files for the vocal tract.

The code was created by Hannah Schütt in a student project for VTL API 2.2 and is now ported to VTL API 2.4 by Konstantin (Tino) Sering (@derNarr).


As neither Hannah nor Tino are hard core C++ programmers a thorough code review would be nice. There is example code on how to visualize and analyse the exported data in Python. Is there a place where to put these examples?

Tests for the functions are still missing and should be added.