### PR TITLE
Change svg export to export 768x576 pixel "images"

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This repo contains sources of the backend of the articulatory synthesizer [Vocal
 ```
 git clone https://github.com/TUD-STKS/VocalTractLabBackend-dev
 ```
+
 ### Build using CMake (Windows, Linux, macOS)
 - Get the latet release of [CMake for your platform](https://cmake.org/)
 - Create a folder ``out`` inside the cloned repository folder
@@ -40,6 +41,14 @@ or
 cmake --build . --config Release --target VocalTractLabBackend
 ```
 
+### Run tests using shell/command prompt
+- Open a shell/command prompt
+- Navigate to cloned repository folder (not the ``out`` folder from the build process)
+- run the tests by executing ``VtlApiTests`` in the ``lib`` folder created by the build process:
+```
+./lib/VtlApiTests
+```
+
 ### Build using Visual Studio 2019 (Windows)
 - Open ``VocalTractLabApi.sln`` in the folder `build/msw`
 - Build the project ``VocalTractLabApi`` or ``VocalTractLabBackend``
@@ -48,13 +57,11 @@ cmake --build . --config Release --target VocalTractLabBackend
 To include the VocalTractLab backend into your own projects, add the folder `include` from this repository to your project's include directories and link against the API or static backend library in the folder `lib`. 
 
 You can then include the API functions like so:
-
 ```cpp
 #include "VocalTractLabApi/VocalTractLabApi.h"
 ```
 
 C++-Objects can be included from the static backend library through their respective header:
-
 ```cpp
 #include "VocalTractLabBackend/Speaker.h"  // or substitute your desired header here
 ```

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ or
 ```
 cmake --build . --config Release --target VocalTractLabBackend
 ```
+The final dll/so-files and executables are copied to ``../lib/`` so you don't
+find them within the ``out`` folder.
 
 ### Run tests using shell/command prompt
 - Open a shell/command prompt

--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ or
 ```
 cmake --build . --config Release --target VocalTractLabBackend
 ```
-The final dll/so-files and executables are copied to ``../lib/`` so you don't
-find them within the ``out`` folder.
+The final binary files are placed into the subdirectory ``lib`` (of the repository root). Do not look for them in the ``out`` directory, which is only used as a temporary folder for the build process and can be safely deleted once the binaries are built.
 
 ### Run tests using shell/command prompt
 - Open a shell/command prompt

--- a/src/VocalTractLabApi/VocalTractLabApi.cpp
+++ b/src/VocalTractLabApi/VocalTractLabApi.cpp
@@ -272,7 +272,7 @@ int vtlCalcTongueRootAutomatically(bool automaticCalculation)
 
 void vtlGetVersion(char *version)
 {
-  strcpy(version, "API 2.4.1 ");
+  strcpy(version, "API 2.4.2 ");
   strcat(version, __DATE__);
 }
 

--- a/src/VocalTractLabBackend/VocalTract.cpp
+++ b/src/VocalTractLabBackend/VocalTract.cpp
@@ -6840,10 +6840,10 @@ bool VocalTract::exportTractContourSvg(const string &fileName, bool addCenterLin
   // Write the "header and open the svg- and the group element.
 
   os << "<?xml version=\"1.0\" encoding=\"utf-8\"?>" << endl;
-  os << "<svg width=\"720\" height=\"576\" viewBox=\"-170 -100 500 400\" version=\"1.1\" xmlns=\"http://www.w3.org/2000/svg\">" << endl;
+  os << "<svg width=\"768\" height=\"576\" viewBox=\"-170 -90 520 390\" version=\"1.1\" xmlns=\"http://www.w3.org/2000/svg\">" << endl;
   indent += 2;
 
-  os << string(indent, ' ') << "<rect x=\"-170\" y=\"-100\" width=\"100%\" height=\"100%\" fill=\"white\" />" << endl;
+  os << string(indent, ' ') << "<rect x=\"-170\" y=\"-90\" width=\"100%\" height=\"100%\" fill=\"white\" />" << endl;
 
   os << string(indent, ' ') << "<g>" << endl;
   indent += 2;

--- a/src/VocalTractLabBackend/VocalTract.cpp
+++ b/src/VocalTractLabBackend/VocalTract.cpp
@@ -6840,10 +6840,10 @@ bool VocalTract::exportTractContourSvg(const string &fileName, bool addCenterLin
   // Write the "header and open the svg- and the group element.
 
   os << "<?xml version=\"1.0\" encoding=\"utf-8\"?>" << endl;
-  os << "<svg width=\"100%\" height=\"100%\" viewBox=\"-160 -90 480 420\" version=\"1.1\" xmlns=\"http://www.w3.org/2000/svg\">" << endl;
+  os << "<svg width=\"720\" height=\"576\" viewBox=\"-170 -100 500 400\" version=\"1.1\" xmlns=\"http://www.w3.org/2000/svg\">" << endl;
   indent += 2;
 
-  os << string(indent, ' ') << "<rect x=\"-160\" y=\"-90\" width=\"100%\" height=\"100%\" fill=\"white\" />" << endl;
+  os << string(indent, ' ') << "<rect x=\"-170\" y=\"-100\" width=\"100%\" height=\"100%\" fill=\"white\" />" << endl;
 
   os << string(indent, ' ') << "<g>" << endl;
   indent += 2;

--- a/test/VtlApiTests.cpp
+++ b/test/VtlApiTests.cpp
@@ -25,7 +25,7 @@ TEST(ApiTest, Version)
 	char version[64];
 	vtlGetVersion(version);
 	std::string s(version);
-	EXPECT_EQ(s, std::string("API 2.4.1 ") + std::string(__DATE__));
+	EXPECT_EQ(s, std::string("API 2.4.2 ") + std::string(__DATE__));
 }
 
 TEST(ApiTest, Constants)

--- a/test/resources/ExportTractSvg.svg
+++ b/test/resources/ExportTractSvg.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<svg width="720" height="576" viewBox="-170 -100 500 400" version="1.1" xmlns="http://www.w3.org/2000/svg">
-  <rect x="-170" y="-100" width="100%" height="100%" fill="white" />
+<svg width="768" height="576" viewBox="-170 -90 520 390" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <rect x="-170" y="-90" width="100%" height="100%" fill="white" />
   <g>
     <polyline stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none" points="-78.0935 269.8618 -79.6272 194.2618 -122.3501 186.7018 -118.1002 156.4618 -117.0377 148.9018 -112.5412 116.9078 -108.0448 84.9139 -103.5483 52.9200 -95.5797 -3.7800 "/>
     <polyline stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none" points="-92.6100 -3.7800 -92.6100 13.2300 -89.3025 21.7350 -79.3800 30.2400 -79.3800 30.2400 -69.4575 21.7350 -66.1500 13.2300 -66.1500 -3.7800 "/>

--- a/test/resources/ExportTractSvg.svg
+++ b/test/resources/ExportTractSvg.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<svg width="100%" height="100%" viewBox="-160 -90 480 420" version="1.1" xmlns="http://www.w3.org/2000/svg">
-  <rect x="-160" y="-90" width="100%" height="100%" fill="white" />
+<svg width="720" height="576" viewBox="-170 -100 500 400" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <rect x="-170" y="-100" width="100%" height="100%" fill="white" />
   <g>
     <polyline stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none" points="-78.0935 269.8618 -79.6272 194.2618 -122.3501 186.7018 -118.1002 156.4618 -117.0377 148.9018 -112.5412 116.9078 -108.0448 84.9139 -103.5483 52.9200 -95.5797 -3.7800 "/>
     <polyline stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none" points="-92.6100 -3.7800 -92.6100 13.2300 -89.3025 21.7350 -79.3800 30.2400 -79.3800 30.2400 -69.4575 21.7350 -66.1500 13.2300 -66.1500 -3.7800 "/>


### PR DESCRIPTION
Changes dimensions of svg export to 768x576 pixel which corresponds to the 4:3 PAL screen resolution (with square pixel).

https://de.wikipedia.org/wiki/PAL_(Fernsehnorm)

Which should make the output more compatible with different devices like mobile phones, especially after being converted to a video.
